### PR TITLE
Fix issue with image name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         if: ${{ contains(github.ref, 'tags') }}
         run: echo "IMAGE_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - name: Build and publish Docker Image to GitHub Packages Registry
+        uses: VaultVulp/gp-docker-action@1.1.8
+        if: ${{ env.IS_DEPLOYMENT == 'true' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           image-name: docker-emberjs-testing


### PR DESCRIPTION
Fixed issue where the image name contained `docker-emberjs-testing` twice.  The _Get Image Name_ step previously output `careerjsm/docker-emberjs-testing/docker-emberjs-testing` and is now fixed to output `docker-emberjs-testing`.