### PR TITLE
Fixed duplicated repo name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
           docker tag ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }} careerjsm/docker-emberjs-testing:${{ env.IMAGE_TAG }}
-          docker push careerjsm/careerjsm/docker-emberjs-testing:${{ env.IMAGE_TAG }}
+          docker push careerjsm/docker-emberjs-testing:${{ env.IMAGE_TAG }}
       - name: Update Deployment Status (Success)
         if: ${{ env.IS_DEPLOYMENT == 'true' && success() }}
         uses: chrnorm/deployment-status@releases/v1


### PR DESCRIPTION
Fixes the image repo for the _Publish to Docker Hub_ step.  Previously written as `careerjsm/careerjsm/docker-emberjs-test`, now fixed to be `careerjsm/docker-emberjs-test`.