### PR TITLE
Revert base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM node:17-buster
+FROM node:14-stretch
 
 RUN \
   --mount=id=apt-cache,type=cache,target=/var/cache/apt \


### PR DESCRIPTION
Reverting base image from node:17-buster to node:14-stretch. We found that node 17.0.01 in this image created problems when trying to build the hub and the jsm with docker-compose. The issue resulted in an endless loop and was unusable.