### PR TITLE
Bump emberjs-testing node version to 16.19-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN \
   wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
   apt-get update -qqy && \
+  apt-get upgrade -qqy && \
   apt-get -qqy install google-chrome-unstable && \
   ln -s /usr/bin/nodejs /usr/bin/node && \
   npm install bower ember-cli -g && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM node:17-buster
+FROM node:16.19-buster
 
 RUN \
   --mount=id=apt-cache,type=cache,target=/var/cache/apt \


### PR DESCRIPTION
Bump emberjs-testing node version to 16.19-buster